### PR TITLE
Fixed autocomplete display glitch caused by missing "collision: 'none'" option.

### DIFF
--- a/jquery-ui.triggeredAutocomplete.js
+++ b/jquery-ui.triggeredAutocomplete.js
@@ -36,7 +36,7 @@
 
 			this.updateHidden();
 
-		    	$.extend(this.options, {
+			$.extend(this.options, {
 				trigger: "@",
 				allowDuplicates: true
 			});

--- a/jquery-ui.triggeredAutocomplete.js
+++ b/jquery-ui.triggeredAutocomplete.js
@@ -16,10 +16,6 @@
 ;(function ( $, window, document, undefined ) {
 	$.widget("ui.triggeredAutocomplete", $.extend({}, $.ui.autocomplete.prototype, {
 
-		options:{
-			trigger: "@",
-			allowDuplicates: true
-		},
 
 		_create:function() {
 
@@ -39,6 +35,11 @@
 			this.ac._create.apply(this, arguments);
 
 			this.updateHidden();
+
+		    	$.extend(this.options, {
+				trigger: "@",
+				allowDuplicates: true
+			});
 
 			// Select function defined via options.
 			this.options.select = function(event, ui) {
@@ -67,8 +68,6 @@
 			// Don't change the input as you browse the results.
 			this.options.focus = function(event, ui) { return false; }
 			this.menu.options.blur = function(event, ui) { return false; }
-
-			this.options.position = { my: "left top", at: "left bottom" };
 
 			// Any changes made need to update the hidden field.
 			this.element.focus(function() { self.updateHidden(); });


### PR DESCRIPTION
The autocomplete box wasn't displaying properly for many layouts, e.g.
if the input box was in a table with any &lt;td&gt; to its left.
You can see an example of this glitch at:

```
http://jsfiddle.net/taherh/NDjdz/
```

The problem was a missing "collision: 'none'" entry in
the positions attribute of the options.  However, the root issue is that
$.ui.autocomplete.option was being replaced rather than extended
by $.ui.triggeredAutocomplete.

This commit keeps the parent option attribute, and extends it with
the necessary new options for triggeredAutocomplete, and in particular,
keeps $.ui.autocomplete's default for the 'positions' option.

You can see the working autocomplete (represented by this commit) at:

```
http://jsfiddle.net/taherh/MbU2T/
```
