### PR TITLE
Fixes problem with json source url input when data is given in shorter style (without explicit labels/values)

### DIFF
--- a/jquery-ui.triggeredAutocomplete.js
+++ b/jquery-ui.triggeredAutocomplete.js
@@ -158,14 +158,15 @@
 						success: function(data) {
 							if(data != null) {
 								response($.map(data, function(item) {
-
+									if (typeof item === "string") {
+										label = item;
+									}
+									else {
+										label = item.label;
+									}
 									// If the item has already been selected don't re-include it.
-									if(!self.id_map[item.label] || self.options.allowDuplicates) {
-										return {
-											label: item.label,
-											value: item.value,
-											img: item.img
-										}
+									if(!self.id_map[label] || self.options.allowDuplicates) {
+										return item
 									}
 								}));
 								self.stopLength = -1;


### PR DESCRIPTION
The json url source feature wasn't working when autocomplete data was
returned in the short style, e.g.:

```
["java", "javascript"]
```

It was only working when the json data was given in the longer style
that includes separate label/value fields, e.g.:

   [ {label: "java", value: "java language"},
     {label: "javascript", value: "javascript language"} ]

This commit provides a fix so that (as with the original jquery.ui.autocomplete)
both forms are acceptable as json source data.  (When the data was provided
inline, there was no problem with either data style -- the problem only
occurs when retrieved via a a json request from source url)

You can see the failure case here:

```
http://jsfiddle.net/taherh/6vjGE/
```

and the fix from this commit here:

```
http://jsfiddle.net/taherh/gVPAQ/
```

The example json source used by the jsfiddles is a gist at:

```
https://gist.github.com/2933428
```

that is accessed via the autocomplete souce param:

```
 "source: '/gh/gist/response.json/2933428/'"
```
