### PR TITLE
Fixing options field merging (my original fix was flawed)

### DIFF
--- a/jquery-ui.triggeredAutocomplete.js
+++ b/jquery-ui.triggeredAutocomplete.js
@@ -14,8 +14,12 @@
 */
 
 ;(function ( $, window, document, undefined ) {
-	$.widget("ui.triggeredAutocomplete", $.extend({}, $.ui.autocomplete.prototype, {
-
+	$.widget("ui.triggeredAutocomplete", $.extend(true, {}, $.ui.autocomplete.prototype, {
+		
+		options: {
+			trigger: "@",
+			allowDuplicates: true
+		},
 
 		_create:function() {
 
@@ -35,11 +39,6 @@
 			this.ac._create.apply(this, arguments);
 
 			this.updateHidden();
-
-			$.extend(this.options, {
-				trigger: "@",
-				allowDuplicates: true
-			});
 
 			// Select function defined via options.
 			this.options.select = function(event, ui) {


### PR DESCRIPTION
My fix for the options field given in commit 08b7b7d was incorrect, in that
it doesn't properly handle options passed in by the user (basically,
options should not be set in _create() as that will override anything the
user specifies).  In particular, this means they won't be able to specify a
different trigger.  

This commit provides a better (and simpler) fix to the
original issue: specifing 'true' as the first param to $.extend() will force
a deep copy, which means the options from the ui.triggeredAutocomplete and
ui.autocomplete will be properly merged.

A working demo of the fix (with the trigger overriden with "-") is at:

  http://jsfiddle.net/taherh/3Trja/
